### PR TITLE
Fix validation workflow missing full history checkout

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -11,6 +11,9 @@ jobs:
   validate-hacs:
     runs-on: "ubuntu-latest"
     steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: HACS validation
         uses: "hacs/action@main"
         with:


### PR DESCRIPTION
## Summary
- Ensure HACS validation workflow checks out full repository history so HACS action can validate branches

## Testing
- `pip install yamllint` *(fails: Could not find a version that satisfies the requirement yamllint; 403 Forbidden)*
- `yamllint .github/workflows/validate.yaml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a456dcc28c8329bcf61034e2ac9e02