### PR TITLE
Allow newer pymodbus versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ And turn on:
 > Turn off scheduled (dis)charging in the web UI to avoid unexpected behavior.
 
 > [!IMPORTANT]
-> When using multiple integrations that use pymodbus package it can lead to version conflicts as they will share 1 package in HA. This can be fixed by removing ALL integrations using pymodbus and modbus configuratio.yaml (for the build in integration into HA), rebooting HA and then reinstalling the integrations and the modbus configuration yaml.
+> This integration requires `pymodbus` 3.9.2 or newer. When using multiple integrations that use the `pymodbus` package it can lead to version conflicts as they will share one package in HA. This can be fixed by removing ALL integrations using pymodbus and modbus configuration.yaml (for the built-in integration into HA), rebooting HA and then reinstalling the integrations and the modbus configuration yaml.
 
 > [!IMPORTANT]
 > Update your GEN24 inverter firmware to 1.34.6-1 or higher otherwise battery charging might be limited.

--- a/custom_components/fronius_modbus/hub.py
+++ b/custom_components/fronius_modbus/hub.py
@@ -22,7 +22,7 @@ _LOGGER = logging.getLogger(__name__)
 class Hub:
     """Hub for Fronius Battery Storage Modbus Interface"""
 
-    PYMODBUS_VERSION = '3.8.3'
+    PYMODBUS_VERSION = '3.9.2'
 
     def __init__(self, hass: HomeAssistant, name: str, host: str, port: int, inverter_unit_id: int, meter_unit_ids, scan_interval: int) -> None:
         """Init hub."""

--- a/custom_components/fronius_modbus/manifest.json
+++ b/custom_components/fronius_modbus/manifest.json
@@ -7,6 +7,6 @@
     "documentation": "https://github.com/redpomodoro/fronius_modbus/",
     "iot_class": "local_polling",
     "issue_tracker": "https://github.com/redpomodoro/fronius_modbus/issues",
-    "requirements": ["pymodbus==3.8.3"],
+    "requirements": ["pymodbus>=3.9.2"],
     "version": "0.1.7"
   }


### PR DESCRIPTION
## Summary
- allow installation with pymodbus>=3.9.2
- update hub to check for pymodbus 3.9.2
- document new pymodbus version requirement

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a46870d4a083298fbc76888457c7ba