### PR TITLE
Use watt values for grid power limits

### DIFF
--- a/custom_components/fronius_modbus/base.py
+++ b/custom_components/fronius_modbus/base.py
@@ -14,7 +14,6 @@ class FroniusModbusBaseEntity():
         self._hub:Hub = hub
         self._key = key
         self._name = name
-        self._unit_of_measurement = unit
         self._icon = icon
         self._device_info = device_info
         if not device_class is None:
@@ -23,16 +22,20 @@ class FroniusModbusBaseEntity():
             self._attr_state_class = state_class
         if not entity_category is None:
             self._attr_entity_category = entity_category
-        if not options is None:
+        if unit is not None:
+            # use native units to support numbers and sensors
+            self._attr_native_unit_of_measurement = unit
+            self._attr_unit_of_measurement = unit
+        if options is not None:
             self._options_dict = options
             self._attr_options = list(options.values())
-        if not min is None:
+        if min is not None:
             self._attr_native_min_value = min
-        if not max is None:
+        if max is not None:
             self._attr_native_max_value = max
-        if not native_step is None:
+        if native_step is not None:
             self._attr_native_step = native_step
-        if not mode is None:
+        if mode is not None:
             self._attr_mode = mode
 
         self._attr_has_entity_name = True
@@ -59,7 +62,7 @@ class FroniusModbusBaseEntity():
     @property
     def unit_of_measurement(self):
         """Return the unit of measurement."""
-        return self._unit_of_measurement
+        return self._attr_native_unit_of_measurement
 
     @property
     def icon(self):

--- a/custom_components/fronius_modbus/number.py
+++ b/custom_components/fronius_modbus/number.py
@@ -51,30 +51,24 @@ async def async_setup_entry(hass, config_entry, async_add_entities) -> None:
     return True
 
 class FroniusModbusNumber(FroniusModbusBaseEntity, NumberEntity):
-    """Representation of an Battery Storage Modbus number."""
+    """Representation of a Battery Storage Modbus number."""
 
     @property
-    def state(self):
-        """Return the state of the sensor."""
+    def native_value(self) -> float | None:
+        """Return the current value in watts."""
 
-        if self._key in self._hub.data:
-            if self._key in ['grid_discharge_power','discharge_limit']:
-                value = round(self._hub.data[self._key] / 100.0 * self._hub.max_discharge_rate_w,0)
-            elif self._key in ['grid_charge_power','charge_limit']:
-                value = round(self._hub.data[self._key] / 100.0 * self._hub.max_charge_rate_w,0)
-            else:
-                value = self._hub.data[self._key]    
-            return value
+        if self._key not in self._hub.data:
+            return None
 
-    # @property
-    # def native_value(self) -> float:
-    #     if self._key in self._hub.data:
-    #         _LOGGER.debug(f'native_value {self._key}')
-    #         if self._key in ['grid_discharge_power','discharge_limit']:
-    #             return self._hub.data[self._key]/100.0 * self._hub.max_discharge_rate_w
-    #         elif self._key in ['grid_charge_power','charge_limit']:
-    #             return self._hub.data[self._key]/100.0 * self._hub.max_charge_rate_w
-    #         return self._hub.data[self._key]
+        if self._key == "discharge_limit":
+            max_rate = self._hub.max_discharge_rate_w or 10000
+            return round(self._hub.data[self._key] / 100.0 * max_rate, 0)
+
+        if self._key == "charge_limit":
+            max_rate = self._hub.max_charge_rate_w or 10000
+            return round(self._hub.data[self._key] / 100.0 * max_rate, 0)
+
+        return self._hub.data[self._key]
 
     async def async_set_native_value(self, value: float) -> None:
         """Change the selected value."""


### PR DESCRIPTION
## Summary
- return grid charge/discharge power as raw watts
- persist charge/discharge limits internally as percentages
- default max charge/discharge rates to 10 000 W
- expose watt-based number values with proper native units

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5a5f13b9c83299af0e9fe0d1e3870