### PR TITLE
Restore battery control mode selection

### DIFF
--- a/custom_components/fronius_modbus/select.py
+++ b/custom_components/fronius_modbus/select.py
@@ -6,6 +6,7 @@ from .const import (
 )
 
 from homeassistant.components.select import SelectEntity
+from homeassistant.helpers.entity import EntityCategory
 
 from .hub import Hub
 from .base import FroniusModbusBaseEntity
@@ -27,6 +28,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities) -> None:
                 name=select_info[0],
                 key=select_info[1],
                 options=select_info[2],
+                entity_category=EntityCategory.CONFIG,
             )
             entities.append(select)
 


### PR DESCRIPTION
## Summary
- Revert regression in control mode handling
- Expose storage control mode as configurable select entity

## Testing
- `python -m py_compile custom_components/fronius_modbus/select.py`
- `python -m py_compile custom_components/fronius_modbus/froniusmodbusclient.py`


------
https://chatgpt.com/codex/tasks/task_e_68a5b55a18e88329b6419017ccaac591