### PR TITLE
Add verified Fronius solar output control

### DIFF
--- a/.github/workflows/hassfest.yaml
+++ b/.github/workflows/hassfest.yaml
@@ -11,4 +11,6 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - uses: "actions/checkout@v3"
+      - name: Compile integration Python
+        run: python -m compileall -q custom_components/fronius_modbus
       - uses: home-assistant/actions/hassfest@master

--- a/README.md
+++ b/README.md
@@ -109,14 +109,15 @@ The integration creates Home Assistant devices for the inverter, configured smar
 
 ## Solar-output controls
 
-Two manual controls are created on the inverter device:
+Three manual controls are created on the inverter device:
 
 | Entity | Options/range | Description |
 | --- | --- | --- |
 | Solar output control | `Auto`, `Limited` | `Auto` disables the SunSpec active-power ceiling. `Limited` applies the configured ceiling. |
-| Solar output limit | `0` W to detected inverter maximum, step `10` W | Active-power ceiling for the inverter. The integration converts watts to the SunSpec percentage value and verifies every write by reading it back. |
+| Solar output limit percentage | `0`% to `100`%, step `0.01`% | Direct control of SunSpec Model 123 `WMaxLimPct`. The percentage is relative to the inverter's nominal power. |
+| Solar output limit | `0` W to detected inverter maximum, step `10` W | Convenience wrapper for the same active-power ceiling. The integration converts watts to `WMaxLimPct`. |
 
-Set **Solar output limit** before selecting **Limited**. Select **Auto** to remove the ceiling and return output control to the inverter. The limit applies to inverter AC output; it is not a closed-loop grid-export limit. Battery charging and site load can therefore affect the grid-meter reading.
+Set either output-limit entity before selecting **Limited**. Both entities control the same register and therefore remain synchronized. For a 10 kW inverter, `10`% is 1000 W, `1`% is 100 W, and `0`% is 0 W. Select **Auto** to remove the ceiling and return output control to the inverter. The limit applies to inverter AC output; it is not a closed-loop grid-export limit. Battery charging and site load can therefore affect the grid-meter reading.
 
 GEN24 output changes are ramped rather than instantaneous. Allow roughly 90–100 seconds before deciding that a new ceiling has not taken effect. Another active controller, such as Solar.web/Amber cloud control or a higher-priority local rule, can override the Modbus command; Modbus must be allowed in the inverter settings and placed at the intended control priority.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Unofficial Home Assistant custom integration for reading Fronius GEN24 inverter,
 ## Current state
 
 - Integration domain: `fronius_modbus`.
-- Current manifest version: `0.1.7`.
+- Current manifest version: `0.2.0`.
 - Home Assistant platforms: `sensor`, `number`, and `select`.
 - Connection type: local Modbus TCP polling.
 - Default port: `502`.
@@ -106,6 +106,21 @@ The integration creates Home Assistant devices for the inverter, configured smar
 | Fixed power factor | Fixed power factor enable state. |
 | Limit VAr control | Reactive-power limit enable state. |
 | Modbus ID | Inverter Modbus unit ID. |
+
+## Solar-output controls
+
+Two manual controls are created on the inverter device:
+
+| Entity | Options/range | Description |
+| --- | --- | --- |
+| Solar output control | `Auto`, `Limited` | `Auto` disables the SunSpec active-power ceiling. `Limited` applies the configured ceiling. |
+| Solar output limit | `0` W to detected inverter maximum, step `10` W | Active-power ceiling for the inverter. The integration converts watts to the SunSpec percentage value and verifies every write by reading it back. |
+
+Set **Solar output limit** before selecting **Limited**. Select **Auto** to remove the ceiling and return output control to the inverter. The limit applies to inverter AC output; it is not a closed-loop grid-export limit. Battery charging and site load can therefore affect the grid-meter reading.
+
+GEN24 output changes are ramped rather than instantaneous. Allow roughly 90–100 seconds before deciding that a new ceiling has not taken effect. Another active controller, such as Solar.web/Amber cloud control or a higher-priority local rule, can override the Modbus command; Modbus must be allowed in the inverter settings and placed at the intended control priority.
+
+> A value of `0` W is supported, but test a nonzero limit first on each inverter/firmware combination. The integration keeps the inverter grid-connected and uses the power-reduction control; it does not write the standby/disconnect command.
 
 ### Smart meter sensors
 

--- a/custom_components/fronius_modbus/config_flow.py
+++ b/custom_components/fronius_modbus/config_flow.py
@@ -71,15 +71,16 @@ async def validate_input(hass: HomeAssistant, data: dict) -> dict[str, Any]:
         _LOGGER.error(f"Modbus addresses are not unique {all_addresses}")
         raise AddressesNotUnique
 
+    hub = Hub(hass, data[CONF_NAME], data[CONF_HOST], data[CONF_PORT], data[CONF_INVERTER_UNIT_ID], meter_addresses, data[CONF_SCAN_INTERVAL])
     try:
-        hub = Hub(hass, data[CONF_NAME], data[CONF_HOST], data[CONF_PORT], data[CONF_INVERTER_UNIT_ID], meter_addresses, data[CONF_SCAN_INTERVAL])
-
         await hub.init_data()
     except Exception as e:
         # If there is an error, raise an exception to notify HA that there was a
         # problem. The UI will also show there was a problem
         _LOGGER.error(f"Cannot start hub {e}")
         raise CannotConnect
+    finally:
+        hub.close()
 
     manufacturer = hub.data.get('i_manufacturer')
     if manufacturer is None:

--- a/custom_components/fronius_modbus/extmodbusclient.py
+++ b/custom_components/fronius_modbus/extmodbusclient.py
@@ -125,15 +125,16 @@ class ExtModbusClient:
 
     async def get_registers(self, unit_id, address, count, retries = 0):
         data = await self.read_holding_registers(unit_id=unit_id, address=address, count=count)
+        if data is None:
+            return None
         if data.isError():
-            if isinstance(data,ModbusIOException):
-                if retries < 1:
-                    _LOGGER.debug(f"IO Error: {data}. Retrying...")
-                    return await self.get_registers(address=address, count=count, retries = retries + 1)
-                else:
-                    _LOGGER.error(f"error reading register: {address} count: {count} unit id: {unit_id} error: {data} ")
-            else:
-                _LOGGER.error(f"error reading register: {address} count: {count} unit id: {unit_id} error: {data} ")
+            _LOGGER.error(
+                "error reading register: %s count: %s unit id: %s error: %s",
+                address,
+                count,
+                unit_id,
+                data,
+            )
             return None
         return data.registers
 

--- a/custom_components/fronius_modbus/froniusmodbusclient.py
+++ b/custom_components/fronius_modbus/froniusmodbusclient.py
@@ -32,6 +32,7 @@ from .froniusmodbusclient_const import (
     GRID_STATUS,
 #    INVERTER_STATUS,
 #    CONNECTION_STATUS,
+    WMAX_LIM_ENA_ADDRESS,
     WMAX_LIM_PCT_ADDRESS,
     CONN_CONTROL_ADDRESS,
     IMMEDIATE_CONTROL_DATA_ADDRESS,
@@ -757,13 +758,14 @@ class FroniusModbusClient(ExtModbusClient):
         pct = self.data.get('WMaxLimPct', 100.0)
         raw_pct = self._pv_pct_to_raw(pct)
 
-        # Fronius recommends writing the complete five-register power-reduction
-        # block in one function-code 0x10 request. Re-writing Ena also applies a
-        # changed setpoint when the mode is already active.
+        # GEN24 applies this control reliably only when WMaxLimPct and
+        # WMaxLim_Ena arrive as distinct FC16 commands. A combined five-register
+        # write is acknowledged and reflected in Model 123 but does not curtail
+        # output on the tested firmware.
         await self.write_registers(
             unit_id=self._inverter_unit_id,
-            address=WMAX_LIM_PCT_ADDRESS,
-            payload=[raw_pct, 0, 0, 0, 1 if enabled else 0],
+            address=WMAX_LIM_ENA_ADDRESS,
+            payload=[1 if enabled else 0],
         )
         await self._verify_pv_limit(raw_pct, enabled)
 
@@ -774,17 +776,30 @@ class FroniusModbusClient(ExtModbusClient):
         pct = max(0.0, min(100.0, pct))
         raw_pct = self._pv_pct_to_raw(pct)
         enabled = self.data.get('WMaxLim_Ena') == CONTROL_STATUS[1]
+
+        # Retrigger an active limit around the new setpoint. Keeping the
+        # operations separate, with a short gap, reproduces the sequence that
+        # physically curtailed the inverter during the live regression test.
         if enabled:
             await self.write_registers(
                 unit_id=self._inverter_unit_id,
-                address=WMAX_LIM_PCT_ADDRESS,
-                payload=[raw_pct, 0, 0, 0, 1],
+                address=WMAX_LIM_ENA_ADDRESS,
+                payload=[0],
             )
-        else:
+            await asyncio.sleep(1)
+
+        await self.write_registers(
+            unit_id=self._inverter_unit_id,
+            address=WMAX_LIM_PCT_ADDRESS,
+            payload=[raw_pct],
+        )
+        await asyncio.sleep(1)
+
+        if enabled:
             await self.write_registers(
                 unit_id=self._inverter_unit_id,
-                address=WMAX_LIM_PCT_ADDRESS,
-                payload=[raw_pct],
+                address=WMAX_LIM_ENA_ADDRESS,
+                payload=[1],
             )
         await self._verify_pv_limit(raw_pct, enabled)
 

--- a/custom_components/fronius_modbus/froniusmodbusclient.py
+++ b/custom_components/fronius_modbus/froniusmodbusclient.py
@@ -32,9 +32,9 @@ from .froniusmodbusclient_const import (
     GRID_STATUS,
 #    INVERTER_STATUS,
 #    CONNECTION_STATUS,
-    WMAX_LIM_ENA_ADDRESS,
     WMAX_LIM_PCT_ADDRESS,
     CONN_CONTROL_ADDRESS,
+    IMMEDIATE_CONTROL_DATA_ADDRESS,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -63,6 +63,10 @@ class FroniusModbusClient(ExtModbusClient):
 
         self._inverter_frequency_lower_bound = self._grid_frequency - 5
         self._inverter_frequency_upper_bound = self._grid_frequency + 5
+
+        # Fronius GEN24 int+SF currently reports -2, but SunSpec requires
+        # clients to read and apply the scale factor rather than assume it.
+        self.wmax_limit_pct_sf = None
 
         self.data = {}
 
@@ -104,6 +108,24 @@ class FroniusModbusClient(ExtModbusClient):
         if await self.read_inverter_nameplate_data() == False:
             _LOGGER.error(f"Error reading nameplate data", exc_info=True)
 
+        # Read the inverter rating and current control state before entities are
+        # created. This supplies the correct range and initial state for the
+        # manual solar-output controls.
+        if await self.read_inverter_model_settings_data() == False:
+            _LOGGER.error("Error reading initial inverter model settings")
+        if await self.read_inverter_controls_data() == False:
+            _LOGGER.error("Error reading initial inverter controls")
+
+        # Populate storage controls before Home Assistant creates number entities.
+        # Without this initial read, controls such as minimum reserve do not yet
+        # exist in self.data and raise a KeyError during platform setup.
+        if self.storage_configured:
+            try:
+                if await self.read_inverter_storage_data() == False:
+                    _LOGGER.error("Error reading initial storage data")
+            except Exception:
+                _LOGGER.error("Error reading initial storage data", exc_info=True)
+
         _LOGGER.debug(f"Init done. data: {self.data}")
 
         #await self.set_active_power_control_enabled(True)
@@ -119,7 +141,7 @@ class FroniusModbusClient(ExtModbusClient):
         url = f"http://{self._host}/solar_api/v1/GetStorageRealtimeData.cgi"
 
         try:
-            response = requests.get(url)
+            response = requests.get(url, timeout=10)
 
             if response.status_code == 200:
                 data = response.json()
@@ -214,7 +236,7 @@ class FroniusModbusClient(ExtModbusClient):
         self.data["line_frequency"] = self.calculate_value(Hz, Hz_SF, 2, 0, 100)
         self.data["acenergy"] = self.calculate_value(WH, WH_SF) 
         #self.data["status"] = INVERTER_STATUS[St]
-        self.data["statusvendor"] = FRONIUS_INVERTER_STATUS[StVnd]
+        self.data["statusvendor"] = FRONIUS_INVERTER_STATUS.get(StVnd, f'Unknown ({StVnd})')
         self.data["statusvendor_id"] = StVnd
         #self.data["events1"] = self.bitmask_to_string(EvtVnd1,INVERTER_EVENTS,default='None',bits=32)  
         self.data["events2"] = self.bitmask_to_string(EvtVnd2,INVERTER_EVENTS,default='None',bits=32)  
@@ -264,9 +286,9 @@ class FroniusModbusClient(ExtModbusClient):
 
         StActCtl = self._client.convert_from_registers(regs[33:35], data_type = self._client.DATATYPE.UINT32)
         
-        self.data['pv_connection'] = CONNECTION_STATUS_CONDENSED[PVConn]
-        self.data['storage_connection'] = CONNECTION_STATUS_CONDENSED[StorConn] 
-        self.data['ecp_connection'] = ECP_CONNECTION_STATUS[ECPConn]
+        self.data['pv_connection'] = CONNECTION_STATUS_CONDENSED.get(PVConn, f'Unknown ({PVConn})')
+        self.data['storage_connection'] = CONNECTION_STATUS_CONDENSED.get(StorConn, f'Unknown ({StorConn})')
+        self.data['ecp_connection'] = ECP_CONNECTION_STATUS.get(ECPConn, f'Unknown ({ECPConn})')
         self.data['inverter_controls'] = self.bitmask_to_string(StActCtl, INVERTER_CONTROLS, 'Normal')  
 
         return True
@@ -291,28 +313,43 @@ class FroniusModbusClient(ExtModbusClient):
         return True
 
     async def read_inverter_controls_data(self):
-        regs = await self.get_registers(unit_id=self._inverter_unit_id, address=40229, count=24)
+        regs = await self.get_registers(
+            unit_id=self._inverter_unit_id,
+            address=IMMEDIATE_CONTROL_DATA_ADDRESS,
+            count=24,
+        )
         if regs is None:
             return False
 
         Conn = self._client.convert_from_registers(regs[2:3], data_type = self._client.DATATYPE.UINT16)
-        ActPwrMod = self._client.convert_from_registers(regs[6:7], data_type=self._client.DATATYPE.UINT16)
+        WMaxLimPct = self._client.convert_from_registers(regs[3:4], data_type=self._client.DATATYPE.UINT16)
         WMaxLim_Ena = self._client.convert_from_registers(regs[7:8], data_type = self._client.DATATYPE.UINT16)
-        WMaxLimPct = self._client.convert_from_registers(regs[8:9], data_type=self._client.DATATYPE.UINT16)
         OutPFSet_Ena = self._client.convert_from_registers(regs[12:13], data_type = self._client.DATATYPE.UINT16)
         VArPct_Ena = self._client.convert_from_registers(regs[20:21], data_type = self._client.DATATYPE.INT16)
-
-        self.data['Conn'] = CONTROL_STATUS[Conn]
-        self.data['ActPwrMod'] = ActPwrMod
-        self.data['WMaxLim_Ena'] = CONTROL_STATUS[WMaxLim_Ena]
-        self.data['WMaxLimPct'] = WMaxLimPct / 100.0
-        self.data['OutPFSet_Ena'] = CONTROL_STATUS[OutPFSet_Ena]
-        self.data['VArPct_Ena'] = CONTROL_STATUS[VArPct_Ena]
-
-        _LOGGER.debug(
-            "DER Active Power Mode: ActPwrMod=%s (raw)", 
-            ActPwrMod
+        WMaxLimPct_SF = self._client.convert_from_registers(
+            regs[21:22], data_type=self._client.DATATYPE.INT16
         )
+
+        # A uint16 register must be able to represent the full 0–100% range.
+        if not -2 <= WMaxLimPct_SF <= 0:
+            _LOGGER.error(
+                "Unsupported WMaxLimPct scale factor: %s", WMaxLimPct_SF
+            )
+            return False
+
+        limit_pct = self.calculate_value(WMaxLimPct, WMaxLimPct_SF, 2, 0, 100)
+        if limit_pct is None:
+            return False
+        self.wmax_limit_pct_sf = WMaxLimPct_SF
+
+        self.data['Conn'] = CONTROL_STATUS.get(Conn, f'Unknown ({Conn})')
+        self.data['WMaxLim_Ena'] = CONTROL_STATUS.get(WMaxLim_Ena, f'Unknown ({WMaxLim_Ena})')
+        self.data['WMaxLimPct'] = limit_pct
+        max_power = self.data.get('max_power')
+        if max_power is not None:
+            self.data['pv_output_limit_w'] = round(max_power * limit_pct / 100.0)
+        self.data['OutPFSet_Ena'] = CONTROL_STATUS.get(OutPFSet_Ena, f'Unknown ({OutPFSet_Ena})')
+        self.data['VArPct_Ena'] = CONTROL_STATUS.get(VArPct_Ena, f'Unknown ({VArPct_Ena})')
 
         _LOGGER.debug("PV limit: Ena=%s Pct=%s", self.data.get('WMaxLim_Ena'), self.data.get('WMaxLimPct'))
         
@@ -479,15 +516,15 @@ class FroniusModbusClient(ExtModbusClient):
             self.data['ext_control_mode'] = STORAGE_EXT_CONTROL_MODE[ext_control_mode]
             self.storage_extended_control_mode = ext_control_mode
 
-        if ext_control_mode == 7:
+        if self.storage_extended_control_mode == 8:
             soc = self.data.get('soc')
             if storage_control_mode == 2 and soc == 100:
                 _LOGGER.error(f'Calibration hit 100%, start discharge')
-                self.change_settings(1, 0, 100, 0)
+                await self.change_settings(1, 0, 100, 0)
             elif storage_control_mode == 3 and soc <= 5: 
                 _LOGGER.error(f'Calibration hit 5%, return to auto mode')
-                self.set_auto_mode()
-                self.set_minimum_reserve(30)
+                await self.set_auto_mode()
+                await self.set_minimum_reserve(30)
                 self.data['ext_control_mode'] = STORAGE_EXT_CONTROL_MODE[0]
                 self.storage_extended_control_mode = 0
 
@@ -715,24 +752,96 @@ class FroniusModbusClient(ExtModbusClient):
 
     async def set_pv_limit_enabled(self, enabled: bool):
         """Enable or disable inverter active power (PV) limiting."""
-        await self.write_registers(
-            unit_id=self._inverter_unit_id,
-            address=WMAX_LIM_ENA_ADDRESS,
-            payload=[1 if enabled else 0],
-        )
+        if not await self.read_inverter_controls_data():
+            raise RuntimeError("Unable to read inverter output controls before write")
+        pct = self.data.get('WMaxLimPct', 100.0)
+        raw_pct = self._pv_pct_to_raw(pct)
 
-    async def set_pv_limit_pct(self, pct: float):
-        """Set inverter active power limit as a percentage (0–100)."""
-        pct = max(0.0, min(100.0, pct))
+        # Fronius recommends writing the complete five-register power-reduction
+        # block in one function-code 0x10 request. Re-writing Ena also applies a
+        # changed setpoint when the mode is already active.
         await self.write_registers(
             unit_id=self._inverter_unit_id,
             address=WMAX_LIM_PCT_ADDRESS,
-            payload=[int(pct * 100)],
+            payload=[raw_pct, 0, 0, 0, 1 if enabled else 0],
         )
-        self.data['WMaxLimPct'] = pct
+        await self._verify_pv_limit(raw_pct, enabled)
+
+    async def set_pv_limit_pct(self, pct: float):
+        """Set inverter active power limit as a percentage (0–100)."""
+        if not await self.read_inverter_controls_data():
+            raise RuntimeError("Unable to read inverter output controls before write")
+        pct = max(0.0, min(100.0, pct))
+        raw_pct = self._pv_pct_to_raw(pct)
+        enabled = self.data.get('WMaxLim_Ena') == CONTROL_STATUS[1]
+        if enabled:
+            await self.write_registers(
+                unit_id=self._inverter_unit_id,
+                address=WMAX_LIM_PCT_ADDRESS,
+                payload=[raw_pct, 0, 0, 0, 1],
+            )
+        else:
+            await self.write_registers(
+                unit_id=self._inverter_unit_id,
+                address=WMAX_LIM_PCT_ADDRESS,
+                payload=[raw_pct],
+            )
+        await self._verify_pv_limit(raw_pct, enabled)
+
+    async def set_pv_output_limit_w(self, watts: float):
+        """Set the inverter output limit in watts, relative to nameplate power."""
+        max_power = self.data.get('max_power')
+        if not max_power or max_power <= 0:
+            raise ValueError("Inverter maximum power is unavailable")
+        watts = max(0.0, min(float(max_power), float(watts)))
+        await self.set_pv_limit_pct(watts / max_power * 100.0)
+
+    async def _verify_pv_limit(self, expected_raw_pct: int, expected_enabled: bool):
+        """Read back the active-power controls after a write."""
+        await asyncio.sleep(0.2)
+        regs = await self.get_registers(
+            unit_id=self._inverter_unit_id,
+            address=WMAX_LIM_PCT_ADDRESS,
+            count=5,
+        )
+        if regs is None:
+            raise RuntimeError("Unable to verify inverter output limit")
+        actual_raw_pct = regs[0]
+        actual_enabled = regs[4] == 1
+        if actual_raw_pct != expected_raw_pct or actual_enabled != expected_enabled:
+            raise RuntimeError(
+                "Inverter output limit verification failed: "
+                f"expected pct={expected_raw_pct} enabled={expected_enabled}, "
+                f"received pct={actual_raw_pct} enabled={regs[4]}"
+            )
+        actual_pct = self._pv_raw_to_pct(actual_raw_pct)
+        self.data['WMaxLimPct'] = actual_pct
+        self.data['WMaxLim_Ena'] = CONTROL_STATUS[1 if actual_enabled else 0]
+        max_power = self.data.get('max_power')
+        if max_power is not None:
+            self.data['pv_output_limit_w'] = round(
+                max_power * actual_pct / 100.0
+            )
+
+    def _pv_pct_to_raw(self, pct: float) -> int:
+        """Convert a percentage to the inverter's scaled register value."""
+        if self.wmax_limit_pct_sf is None:
+            raise RuntimeError("Inverter output-limit scale factor is unavailable")
+        raw_pct = round(
+            max(0.0, min(100.0, pct)) / 10**self.wmax_limit_pct_sf
+        )
+        if not 0 <= raw_pct <= 65534:
+            raise ValueError(f"Scaled inverter output limit is invalid: {raw_pct}")
+        return raw_pct
+
+    def _pv_raw_to_pct(self, raw_pct: int) -> float:
+        """Convert the inverter's scaled register value to a percentage."""
+        if self.wmax_limit_pct_sf is None:
+            raise RuntimeError("Inverter output-limit scale factor is unavailable")
+        return round(raw_pct * 10**self.wmax_limit_pct_sf, 2)
 
     async def set_inverter_control_enabled(self, enabled: bool):
-        """Enable SunSpec inverter control block."""
+        """Put the inverter into grid-feed operation or standby."""
         await self.write_registers(
             unit_id=self._inverter_unit_id,
             address=CONN_CONTROL_ADDRESS,
@@ -740,11 +849,5 @@ class FroniusModbusClient(ExtModbusClient):
         )
 
     async def set_active_power_control_enabled(self, enabled: bool):
-        value = 1 if enabled else 0
-        _LOGGER.warning(f"Setting active power control = {value}")
-
-        await self.write_registers(
-            unit_id=self._inverter_unit_id,
-            address=40229 + 7,  # WMaxLim_Ena offset (already confirmed)
-            payload=[value],
-        )
+        """Compatibility alias for active-power limit enablement."""
+        await self.set_pv_limit_enabled(enabled)

--- a/custom_components/fronius_modbus/froniusmodbusclient_const.py
+++ b/custom_components/fronius_modbus/froniusmodbusclient_const.py
@@ -12,10 +12,12 @@ MINIMUM_RESERVE_ADDRESS = 40350
 DISCHARGE_RATE_ADDRESS = 40355
 CHARGE_RATE_ADDRESS = 40356
 
-# SunSpec / Fronius inverter controls (active power limiting)
+# SunSpec Model 123 immediate controls for the int+SF model. The model starts
+# at 40227 (ID and length); its first data point is at 40229.
+IMMEDIATE_CONTROL_DATA_ADDRESS = 40229
+WMAX_LIM_PCT_ADDRESS = 40232     # WMaxLimPct (uint16, scale factor -2)
 WMAX_LIM_ENA_ADDRESS = 40236     # WMaxLim_Ena (uint16)
-WMAX_LIM_PCT_ADDRESS = 40237     # WMaxLimPct (uint16, scaled x100)
-CONN_CONTROL_ADDRESS = 40231     # Conn (SunSpec inverter control)
+CONN_CONTROL_ADDRESS = 40231     # Conn: 0=standby, 1=grid feed operation
 
 
     # Manufacturer

--- a/custom_components/fronius_modbus/hub.py
+++ b/custom_components/fronius_modbus/hub.py
@@ -314,6 +314,12 @@ class Hub:
         self._notify_entities()
 
     @toggle_busy
+    async def set_pv_limit_pct(self, value):
+        """Set the native SunSpec WMaxLimPct output ceiling."""
+        await self._client.set_pv_limit_pct(value)
+        self._notify_entities()
+
+    @toggle_busy
     async def set_pv_limit_enabled(self, enabled: bool):
         """Enable a configured output ceiling or return to automatic output."""
         await self._client.set_pv_limit_enabled(enabled)

--- a/custom_components/fronius_modbus/hub.py
+++ b/custom_components/fronius_modbus/hub.py
@@ -2,6 +2,8 @@
 from __future__ import annotations
 
 import logging
+import asyncio
+from functools import wraps
 from datetime import timedelta
 from typing import Optional
 from importlib.metadata import version, PackageNotFoundError
@@ -37,24 +39,16 @@ class Hub:
         self._unsub_interval_method = None
         self._entities = []
         self._entities_dict = {}
-        self._busy = False
+        self._operation_lock = asyncio.Lock()
 
     def toggle_busy(func):
+        @wraps(func)
         async def wrapper(self, *args, **kwargs):
-            if self._busy:
-                #_LOGGER.debug(f"skip {func.__name__} hub busy") 
-                return
-            self._busy = True
-            error = None
-            try:
-                result = await func(self, *args, **kwargs)
-            except Exception as e:
-                _LOGGER.warning(f'Exception in wrapper {e}')
-                error = e
-            self._busy = False
-            if not error is None:
-                raise error
-            return result
+            # A control command must wait for an in-progress poll instead of
+            # being silently discarded. asyncio.Lock also releases safely if
+            # the operation raises or is cancelled.
+            async with self._operation_lock:
+                return await func(self, *args, **kwargs)
         return wrapper
 
     @toggle_busy
@@ -79,10 +73,7 @@ class Hub:
             raise Exception(
                 f"pymodbus {installed} found, please update to {self.PYMODBUS_VERSION} or higher"
             )
-        if installed > required:
-            _LOGGER.warning(f"newer pymodbus {installed} found")
-
-        _LOGGER.debug(f"pymodbus {installed}")
+        _LOGGER.debug("pymodbus %s", installed)
 
     @property 
     def device_info_storage(self) -> dict:
@@ -143,63 +134,87 @@ class Hub:
             self._unsub_interval_method = None
             self.close()
 
-    @toggle_busy
     async def async_refresh_modbus_data(self, _now: Optional[int] = None) -> dict:
         """Time to update."""
+
+        # Timer callbacks should not build a backlog while a control write or a
+        # previous slow poll owns the Modbus connection. User-initiated control
+        # writes still wait on the lock and are never silently discarded.
+        if self._operation_lock.locked():
+            _LOGGER.debug("Skipping scheduled refresh while Modbus is busy")
+            return False
+
+        async with self._operation_lock:
+            return await self._async_refresh_modbus_data()
+
+    async def _async_refresh_modbus_data(self) -> bool:
+        """Read all configured models while holding the operation lock."""
 
         if not self._entities:
             return False
 
+        update_results = []
+
         try:
-            update_result = await self._client.read_inverter_data()
+            inverter_result = await self._client.read_inverter_data()
+            update_results.append(inverter_result)
+            self.online = bool(inverter_result)
         except Exception as e:
             _LOGGER.exception("Error reading inverter data", exc_info=True)
-            update_result = False
+            update_results.append(False)
+            self.online = False
 
         try:
-            update_result = await self._client.read_inverter_status_data()
+            update_results.append(await self._client.read_inverter_status_data())
         except Exception as e:
             _LOGGER.exception("Error reading inverter status data", exc_info=True)
-            update_result = False
+            update_results.append(False)
 
         try:
-            update_result = await self._client.read_inverter_model_settings_data()
+            update_results.append(await self._client.read_inverter_model_settings_data())
         except Exception as e:
             _LOGGER.exception("Error reading inverter model settings data", exc_info=True)
-            update_result = False
+            update_results.append(False)
 
         try:
-            update_result = await self._client.read_inverter_controls_data()
+            update_results.append(await self._client.read_inverter_controls_data())
         except Exception as e:
             _LOGGER.exception("Error reading inverter model settings data", exc_info=True)
-            update_result = False
+            update_results.append(False)
 
         if self._client.meter_configured:
-            for meter_address in self._client._meter_unit_ids:
+            for meter_index, meter_address in enumerate(self._client._meter_unit_ids, start=1):
                 try:
-                    update_result = await self._client.read_meter_data(meter_prefix="m1_", unit_id=meter_address)
+                    update_results.append(
+                        await self._client.read_meter_data(
+                            meter_prefix=f"m{meter_index}_", unit_id=meter_address
+                        )
+                    )
                 except Exception as e:
                     _LOGGER.error(f"Error reading meter data {meter_address}.", exc_info=True)
-                    #update_result = False
+                    update_results.append(False)
 
         if self._client.mppt_configured:
             try:
-                update_result = await self._client.read_mppt_data()
+                update_results.append(await self._client.read_mppt_data())
             except Exception as e:
                 _LOGGER.exception("Error reading mptt data", exc_info=True)
-                update_result = False
+                update_results.append(False)
         
         if self._client.storage_configured:
             try:
-                update_result = await self._client.read_inverter_storage_data()
+                update_results.append(await self._client.read_inverter_storage_data())
             except Exception as e:
                 _LOGGER.exception("Error reading inverter storage data", exc_info=True)
-                update_result = False
+                update_results.append(False)
 
 
-        if update_result:
-            for update_callback in self._entities:
-                update_callback()
+        # Always notify entities so availability and successful partial reads
+        # are reflected even if one optional model failed.
+        for update_callback in self._entities:
+            update_callback()
+
+        return any(update_results)
 
     @toggle_busy
     async def test_connection(self) -> bool:
@@ -238,6 +253,18 @@ class Hub:
     @property
     def storage_extended_control_mode(self):
         return self._client.storage_extended_control_mode
+
+    @property
+    def pv_control_configured(self) -> bool:
+        """Return whether the inverter exposed a usable power-limit block."""
+        max_power = self.data.get("max_power")
+        return (
+            isinstance(max_power, (int, float))
+            and not isinstance(max_power, bool)
+            and max_power > 0
+            and isinstance(self.data.get("WMaxLimPct"), (int, float))
+            and self.data.get("WMaxLim_Ena") in ("Disabled", "Enabled")
+        )
 
     @toggle_busy
     async def set_mode(self, mode):
@@ -280,4 +307,19 @@ class Hub:
     async def set_grid_discharge_power(self, value):
         await self._client.set_grid_discharge_power(value)
 
+    @toggle_busy
+    async def set_pv_output_limit_w(self, value):
+        """Set the inverter output ceiling in watts."""
+        await self._client.set_pv_output_limit_w(value)
+        self._notify_entities()
 
+    @toggle_busy
+    async def set_pv_limit_enabled(self, enabled: bool):
+        """Enable a configured output ceiling or return to automatic output."""
+        await self._client.set_pv_limit_enabled(enabled)
+        self._notify_entities()
+
+    def _notify_entities(self):
+        """Push locally verified control state to all entities."""
+        for update_callback in self._entities:
+            update_callback()

--- a/custom_components/fronius_modbus/manifest.json
+++ b/custom_components/fronius_modbus/manifest.json
@@ -4,9 +4,9 @@
     "codeowners": ["@redpomodoro"],
     "config_flow": true,
     "dependencies": [],
-    "documentation": "https://github.com/redpomodoro/fronius_modbus/",
+    "documentation": "https://github.com/wgshbd1971/fronius_modbus/",
     "iot_class": "local_polling",
-    "issue_tracker": "https://github.com/redpomodoro/fronius_modbus/issues",
+    "issue_tracker": "https://github.com/wgshbd1971/fronius_modbus/issues",
     "requirements": ["pymodbus>=3.9.2"],
-    "version": "0.1.7"
+    "version": "0.2.0"
   }

--- a/custom_components/fronius_modbus/number.py
+++ b/custom_components/fronius_modbus/number.py
@@ -23,19 +23,33 @@ async def async_setup_entry(hass, config_entry, async_add_entities) -> None:
     entities = []
 
     if hub.pv_control_configured:
-        entities.append(
-            FroniusModbusNumber(
-                ENTITY_PREFIX,
-                hub,
-                hub.device_info_inverter,
-                "Solar output limit",
-                "pv_output_limit_w",
-                min=0,
-                max=hub.data["max_power"],
-                unit="W",
-                mode="box",
-                native_step=10,
-            )
+        entities.extend(
+            [
+                FroniusModbusNumber(
+                    ENTITY_PREFIX,
+                    hub,
+                    hub.device_info_inverter,
+                    "Solar output limit percentage",
+                    "WMaxLimPct",
+                    min=0,
+                    max=100,
+                    unit="%",
+                    mode="box",
+                    native_step=0.01,
+                ),
+                FroniusModbusNumber(
+                    ENTITY_PREFIX,
+                    hub,
+                    hub.device_info_inverter,
+                    "Solar output limit",
+                    "pv_output_limit_w",
+                    min=0,
+                    max=hub.data["max_power"],
+                    unit="W",
+                    mode="box",
+                    native_step=10,
+                ),
+            ]
         )
     else:
         _LOGGER.warning(
@@ -114,6 +128,8 @@ class FroniusModbusNumber(FroniusModbusBaseEntity, NumberEntity):
             await self._hub.set_grid_discharge_power(value)
         elif self._key == 'pv_output_limit_w':
             await self._hub.set_pv_output_limit_w(value)
+        elif self._key == 'WMaxLimPct':
+            await self._hub.set_pv_limit_pct(value)
 
         #_LOGGER.debug(f"Number {self._key} set to {value}")
         self.async_write_ha_state()
@@ -125,7 +141,7 @@ class FroniusModbusNumber(FroniusModbusBaseEntity, NumberEntity):
             return False
         if self._key == 'minimum_reserve':
             return True
-        if self._key == 'pv_output_limit_w':
+        if self._key in ('pv_output_limit_w', 'WMaxLimPct'):
             return self._hub.pv_control_configured
         if self._key == 'charge_limit' and self._hub.storage_extended_control_mode in [1,3,6]:
             return True

--- a/custom_components/fronius_modbus/number.py
+++ b/custom_components/fronius_modbus/number.py
@@ -22,6 +22,27 @@ async def async_setup_entry(hass, config_entry, async_add_entities) -> None:
 
     entities = []
 
+    if hub.pv_control_configured:
+        entities.append(
+            FroniusModbusNumber(
+                ENTITY_PREFIX,
+                hub,
+                hub.device_info_inverter,
+                "Solar output limit",
+                "pv_output_limit_w",
+                min=0,
+                max=hub.data["max_power"],
+                unit="W",
+                mode="box",
+                native_step=10,
+            )
+        )
+    else:
+        _LOGGER.warning(
+            "Solar output controls are unavailable because the inverter did not "
+            "expose a valid SunSpec immediate-control block"
+        )
+
     if hub.storage_configured:
 
         for number_info in STORAGE_NUMBER_TYPES:
@@ -58,18 +79,25 @@ class FroniusModbusNumber(FroniusModbusBaseEntity, NumberEntity):
         """Return the current value in watts."""
 
         if self._key == "discharge_limit":
-            value = self._hub.data[self._key]
+            value = self._hub.data.get(self._key)
+            if value is None:
+                return None
             max_rate = self._hub.max_discharge_rate_w or 10000
             # Only convert when value is percent (Fronius reports 0–100)
             return round(value / 100.0 * max_rate, 0) if value <= 100 else value
 
         if self._key == "charge_limit":
-            value = self._hub.data[self._key]
+            value = self._hub.data.get(self._key)
+            if value is None:
+                return None
             max_rate = self._hub.max_charge_rate_w or 10000
             # Only convert when value is percent (Fronius reports 0–100)
             return round(value / 100.0 * max_rate, 0) if value <= 100 else value
 
-        return self._hub.data[self._key]
+        # Storage data can be briefly absent while the integration starts.
+        # Returning None keeps the entity unavailable until the first good read
+        # instead of aborting entity setup with a KeyError.
+        return self._hub.data.get(self._key)
 
     async def async_set_native_value(self, value: float) -> None:
         """Change the selected value."""
@@ -84,6 +112,8 @@ class FroniusModbusNumber(FroniusModbusBaseEntity, NumberEntity):
             await self._hub.set_grid_charge_power(value)
         elif self._key == 'grid_discharge_power':
             await self._hub.set_grid_discharge_power(value)
+        elif self._key == 'pv_output_limit_w':
+            await self._hub.set_pv_output_limit_w(value)
 
         #_LOGGER.debug(f"Number {self._key} set to {value}")
         self.async_write_ha_state()
@@ -91,8 +121,12 @@ class FroniusModbusNumber(FroniusModbusBaseEntity, NumberEntity):
     @property
     def available(self) -> bool:
         """Return depending on mode."""
+        if not self._hub.online:
+            return False
         if self._key == 'minimum_reserve':
             return True
+        if self._key == 'pv_output_limit_w':
+            return self._hub.pv_control_configured
         if self._key == 'charge_limit' and self._hub.storage_extended_control_mode in [1,3,6]:
             return True
         if self._key == 'discharge_limit' and self._hub.storage_extended_control_mode in [2,3,7]:
@@ -102,4 +136,3 @@ class FroniusModbusNumber(FroniusModbusBaseEntity, NumberEntity):
         if self._key == 'grid_discharge_power' and self._hub.storage_extended_control_mode in [5]:
             return True
         return False
-

--- a/custom_components/fronius_modbus/select.py
+++ b/custom_components/fronius_modbus/select.py
@@ -18,6 +18,18 @@ async def async_setup_entry(hass, config_entry, async_add_entities) -> None:
 
     entities = []
 
+    if hub.pv_control_configured:
+        entities.append(
+            FroniusModbusSolarOutputSelect(
+                platform_name=ENTITY_PREFIX,
+                hub=hub,
+                device_info=hub.device_info_inverter,
+                name="Solar output control",
+                key="pv_output_control",
+                options={0: "Auto", 1: "Limited"},
+            )
+        )
+
     if hub.storage_configured:
         for select_info in STORAGE_SELECT_TYPES:
             select = FroniusModbusSelect(
@@ -59,4 +71,26 @@ class FroniusModbusSelect(FroniusModbusBaseEntity, SelectEntity):
         # self._hub.storage_extended_control_mode = new_mode
         self.async_write_ha_state()
 
+
+class FroniusModbusSolarOutputSelect(FroniusModbusBaseEntity, SelectEntity):
+    """Manual active-power limiting mode."""
+
+    @property
+    def current_option(self) -> str:
+        enabled = self._hub.data.get("WMaxLim_Ena")
+        if enabled == "Enabled":
+            return "Limited"
+        if enabled == "Disabled":
+            return "Auto"
+        return None
+
+    @property
+    def available(self) -> bool:
+        return self._hub.online and self._hub.pv_control_configured
+
+    async def async_select_option(self, option: str) -> None:
+        if option not in self._attr_options:
+            raise ValueError(f"Unsupported solar output mode: {option}")
+        await self._hub.set_pv_limit_enabled(option == "Limited")
+        self.async_write_ha_state()
 


### PR DESCRIPTION
## Summary

- add Home Assistant controls for a Fronius GEN24 inverter output ceiling:
  - **Solar output limit** in watts
  - **Solar output control** with `Auto` and `Limited`
- correct the SunSpec Model 123 int+SF register offsets and read the reported scale factor
- use Fronius' documented five-register power-reduction write, then verify both the setpoint and enable flag by reading them back
- initialise nameplate, solar-control, and storage state before entity creation
- serialize Modbus control operations with polling while skipping overlapping scheduled polls
- harden failed-read handling and config-flow connection cleanup
- document inverter setup, ramp time, cloud/control-priority interactions, and release version `0.2.0`
- compile the integration as part of the existing hassfest workflow

## Regression review

- no existing entity unique IDs were changed
- no Home Assistant automation or YAML files are included
- battery/storage register addresses and public service paths are unchanged
- storage controls are populated during startup so existing battery number/select entities remain available
- control writes wait for an in-progress poll rather than being silently dropped
- scheduled polls do not queue indefinitely when Modbus is busy

## Validation

- exercised on a Fronius Symo GEN24 10.0 Plus with BYD storage
- reduced inverter output from approximately 4.4 kW to approximately 1.0 kW using a 1,000 W limit
- confirmed Fronius' normal 90–100 second ramp behaviour
- verified Model 123 readback at protocol addresses:
  - `40232` WMaxLimPct
  - `40236` WMaxLim_Ena
  - `40250` WMaxLimPct_SF = `-2`
- restored solar control to `Auto`, output limit to 10,000 W, storage mode to `Auto`, and the existing battery automation to enabled
- validated manifest and translation JSON and added Python compilation to CI

## Operational notes

The limit controls total inverter AC output, not closed-loop export at the grid meter. Solar.web/Amber or another higher-priority active controller can override Modbus.